### PR TITLE
Add ports and schema configuration

### DIFF
--- a/src/DevSpector.SDK/Implementation/JsonProvider.cs
+++ b/src/DevSpector.SDK/Implementation/JsonProvider.cs
@@ -19,29 +19,36 @@ namespace DevSpector.SDK
 
         private readonly HttpClient _client;
 
-        public JsonProvider()
+        private readonly int _localhostPort;
+
+        /// <summary>
+        /// Creates provider that targets to localhost
+        /// </summary>
+        public JsonProvider(int port)
         {
+            _localhostPort = port;
+
             _client = new HttpClient();
 
-            _host = BuildDefaultHost();
+            _host = BuildDefaultHost(port);
 
             BuildEndpointPath();
         }
 
-        public JsonProvider(string hostname)
+        public JsonProvider(string hostname, int? port = null)
         {
             _client = new HttpClient();
 
-            _host = BuildHostFrom(hostname);
+            _host = BuildHostFrom(hostname, port);
 
             BuildEndpointPath();
         }
 
-        public JsonProvider(string hostname, HttpClient client)
+        public JsonProvider(string hostname, HttpClient client, int? port = null)
         {
             _client = client;
 
-            _host = BuildHostFrom(hostname);
+            _host = BuildHostFrom(hostname, port);
 
             BuildEndpointPath();
         }
@@ -80,25 +87,26 @@ namespace DevSpector.SDK
             return await response.Content.ReadAsStringAsync();
         }
 
-        private Uri BuildDefaultHost()
+        private Uri BuildDefaultHost(int port)
         {
-            var uriBuilder = CreateHostBuilder();
+            var uriBuilder = CreateHostBuilder(_localhostPort);
             uriBuilder.Host = "localhost";
             return uriBuilder.Uri;
         }
 
-        private Uri BuildHostFrom(string hostname)
+        private Uri BuildHostFrom(string hostname, int? port)
         {
-            var uriBuilder = CreateHostBuilder();
+            var uriBuilder = CreateHostBuilder(port, "https");
             uriBuilder.Host = hostname;
             return uriBuilder.Uri;
         }
 
-        private UriBuilder CreateHostBuilder()
+        private UriBuilder CreateHostBuilder(int? port, string scheme = "http")
         {
             var builder = new UriBuilder();
-            builder.Port = 5000;
-            builder.Scheme= "http";
+            if (port != null)
+                builder.Port = (int)port;
+            builder.Scheme = scheme;
             return builder;
         }
 

--- a/tests/AuthorizationManagerTests.cs
+++ b/tests/AuthorizationManagerTests.cs
@@ -38,8 +38,7 @@ namespace DevSpector.Tests.Common.SDK.Authorization
             var password = "no";
 
             // Act & Assert
-            await Assert.ThrowsAsync(
-                typeof(ArgumentException),
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await manager.TrySignIn(expectedLogin, password)
             );
         }

--- a/tests/JsonProviderTests.cs
+++ b/tests/JsonProviderTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DevSpector.SDK.Tests
+{
+    public class JsonProviderTests
+    {
+        private readonly string _host = "dev-devspector.herokuapp.com";
+
+        [Fact]
+        public async void ThrowsWrongAPI()
+        {
+            // Arrange
+            var provider = new JsonProvider(_host);
+
+            var actions = new Func<Task<string>>[] {
+                async () => await provider.GetDevicesAsync("wrongToken"),
+                async () => await provider.GetFreeIPAsync("wrongToken"),
+                async () => await provider.GetHousingAsync(Guid.Empty, "wrongToken"),
+                async () => await provider.GetHousingsAsync("wrongToken"),
+                async () => await provider.GetUsersAsync("wrongToken")
+            };
+
+
+            // Assert
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => {
+                    foreach (var action in actions)
+                        await action.Invoke();
+                }
+            );
+        }
+
+        [Fact]
+        public void DoesUriBuiltProperly()
+        {
+            // Arrange
+            var expectedHost1 = "testHost1";
+            var expectedPort1 = 1234;
+
+            var expectedHost2 = "testHost2";
+            int expectedPort2 = 443;
+
+            var expectedHost3 = "localhost";
+            var expectedPort3 = 5040;
+
+            // Act
+            var provider1 = new JsonProvider(expectedHost1, expectedPort1);
+            var provider2 = new JsonProvider(expectedHost2);
+            var provider3 = new JsonProvider(expectedPort3);
+
+            var uri1 = provider1.Host;
+            var uri2 = provider2.Host;
+            var uri3 = provider3.Host;
+
+            // Assert
+            Assert.Equal(expectedHost1, uri1.Host, ignoreCase: true);
+            Assert.Equal(expectedPort1, uri1.Port);
+
+            Assert.Equal(expectedHost2, uri2.Host, ignoreCase: true);
+            Assert.Equal(expectedPort2, uri2.Port);
+
+            Assert.Equal(expectedHost3, uri3.Host, ignoreCase: true);
+            Assert.Equal(expectedPort3, uri3.Port);
+        }
+    }
+}


### PR DESCRIPTION
Now when you create ```JsonProvider``` object it can be configured with specified port, http-schema configurates automatically depending on used constructor 